### PR TITLE
squid:S1148 Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/main/java/org/sayem/webdriver/algorithm/Retry.java
+++ b/src/main/java/org/sayem/webdriver/algorithm/Retry.java
@@ -2,12 +2,17 @@ package org.sayem.webdriver.algorithm;
 
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * Created by sayem on 10/05/15.
  */
 @SuppressWarnings("Duplicates")
 public class Retry {
 
+    private static final Logger log = getLogger(Retry.class);
     private final long interval;
     private final TimeUnit unit;
     private boolean on;
@@ -76,7 +81,7 @@ public class Retry {
             return attempt;
         } catch (Exception e) {
             on();
-            e.printStackTrace();
+            log.error("Exception while execution", e);
             if (count == 0) {
                 throw e;
             }
@@ -92,7 +97,7 @@ public class Retry {
         try {
             unit.sleep(interval);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            log.error("Thread has been interrupted", e);
         }
     }
 

--- a/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
+++ b/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.sayem.webdriver.TestBase;
 import org.sayem.webdriver.properties.Repository;
+import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -19,12 +20,14 @@ import java.net.URL;
 import static org.openqa.selenium.Proxy.ProxyType.MANUAL;
 import static org.sayem.webdriver.browsers.config.BrowserType.FIREFOX;
 import static org.sayem.webdriver.browsers.config.BrowserType.valueOf;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Created by sayem on 10/05/15.
  */
 public class BrowserThreads {
 
+    private static final Logger log = getLogger(BrowserThreads.class);
     private final String defaultUrl = System.getProperty("seleniumUrl");
     private final BrowserType defaultBrowserType = getBrowser();
     private final String browser = System.getProperty("browser", defaultBrowserType.toString()).toUpperCase();
@@ -116,7 +119,7 @@ public class BrowserThreads {
             try {
                 seleniumGridURL = new URL(System.getProperty("gridURL"));
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+                log.error("Either no legal protocol could be found or the string could not be parsed.", e);
             }
             String desiredBrowserVersion = System.getProperty("desiredBrowserVersion");
             String desiredPlatform = System.getProperty("desiredPlatform");

--- a/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
+++ b/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
+import org.slf4j.Logger;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 
@@ -12,11 +13,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import static org.sayem.webdriver.TestBase.driver;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Created by sayem on 10/05/15.
  */
 public class ScreenshotListener extends TestListenerAdapter {
+
+    private static final Logger log = getLogger(ScreenshotListener.class);
 
     private boolean createFile(File screenshot) {
         boolean fileCreated = false;
@@ -29,7 +33,7 @@ public class ScreenshotListener extends TestListenerAdapter {
                 try {
                     fileCreated = screenshot.createNewFile();
                 } catch (IOException errorCreatingScreenshot) {
-                    errorCreatingScreenshot.printStackTrace();
+                    log.error("failed or interrupted I/O operations", errorCreatingScreenshot);
                 }
             }
         }

--- a/src/main/java/org/sayem/webdriver/properties/PropertiesUtil.java
+++ b/src/main/java/org/sayem/webdriver/properties/PropertiesUtil.java
@@ -1,14 +1,19 @@
 package org.sayem.webdriver.properties;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
+import org.slf4j.Logger;
+
 /**
  * Created by sayem on 12/28/15.
  */
 public class PropertiesUtil {
+    private static final Logger log = getLogger(PropertiesUtil.class);
     private String dataLocation;
     private Properties properties;
 
@@ -44,7 +49,7 @@ public class PropertiesUtil {
             properties = new Properties();
             properties.load(fileInputStream);
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("failed or interrupted I/O operations", e);;
         }
     }
 
@@ -55,7 +60,7 @@ public class PropertiesUtil {
             prop = properties.getProperty(name);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Exception while execution", e);
         }
         return prop;
     }
@@ -68,7 +73,7 @@ public class PropertiesUtil {
             prop = valueOf(type, temp);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Exception while execution", e);
         }
         return prop;
     }

--- a/src/main/java/org/sayem/webdriver/selenium/Browser.java
+++ b/src/main/java/org/sayem/webdriver/selenium/Browser.java
@@ -120,7 +120,7 @@ public class Browser extends DelegatingWebDriver
         try {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            log.error("Thread has been interrupted", e);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1148 Throwable.printStackTrace(...) should not be called.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1148
Please let me know if you have any questions.
George Kankava