### PR TITLE
squid:S106 Standard outputs should not be used directly to log anything

### DIFF
--- a/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
+++ b/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.sayem.webdriver.TestBase;
 import org.sayem.webdriver.properties.Repository;
+import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -20,11 +21,14 @@ import static org.openqa.selenium.Proxy.ProxyType.MANUAL;
 import static org.sayem.webdriver.browsers.config.BrowserType.FIREFOX;
 import static org.sayem.webdriver.browsers.config.BrowserType.valueOf;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * Created by sayem on 10/05/15.
  */
 public class BrowserThreads {
 
+    private static final Logger log = getLogger(BrowserThreads.class);
     private final String defaultUrl = System.getProperty("seleniumUrl");
     private final BrowserType defaultBrowserType = getBrowser();
     private final String browser = System.getProperty("browser", defaultBrowserType.toString()).toUpperCase();
@@ -97,19 +101,19 @@ public class BrowserThreads {
         try {
             driverType = valueOf(browser);
         } catch (IllegalArgumentException ignored) {
-            System.err.println("Unknown driver specified, defaulting to '" + driverType + "'...");
+            log.error("Unknown driver specified, defaulting to '" + driverType + "'...");
         } catch (NullPointerException ignored) {
-            System.err.println("No driver specified, defaulting to '" + driverType + "'...");
+            log.error("No driver specified, defaulting to '" + driverType + "'...");
         }
         selectedDriverType = driverType;
     }
 
     private void instantiateWebDriver(DesiredCapabilities desiredCapabilities) {
-        System.out.println(" ");
-        System.out.println("Current Operating System: " + operatingSystem);
-        System.out.println("Current Architecture: " + systemArchitecture);
-        System.out.println("Current Browser Selection: " + selectedDriverType);
-        System.out.println(" ");
+        log.info(" ");
+        log.info("Current Operating System: " + operatingSystem);
+        log.info("Current Architecture: " + systemArchitecture);
+        log.info("Current Browser Selection: " + selectedDriverType);
+        log.info(" ");
 
         if (useRemoteWebDriver) {
             URL seleniumGridURL = null;
@@ -139,7 +143,7 @@ public class BrowserThreads {
 
     private void setup() {
         if (defaultUrl.isEmpty()) {
-            System.err.println("No URL specified, defaulting to: " + defaultUrl + "'...");
+            log.error("No URL specified, defaulting to: " + defaultUrl + "'...");
             webdriver.navigate().to(TestBase.getProperties(Repository.URL));
         }else {
             webdriver.navigate().to(defaultUrl);
@@ -151,9 +155,9 @@ public class BrowserThreads {
         try {
             browserType = valueOf(TestBase.getProperties(Repository.BROWSER).toUpperCase());
         } catch (IllegalArgumentException ignored) {
-            System.err.println("Unknown driver specified, defaulting to '" + browserType + "'...");
+            log.error("Unknown driver specified, defaulting to '" + browserType + "'...");
         } catch (NullPointerException ignored) {
-            System.err.println("No driver specified in property, defaulting to '" + browserType + "'...");
+            log.error("No driver specified in property, defaulting to '" + browserType + "'...");
         }
         return browserType;
     }

--- a/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
+++ b/src/main/java/org/sayem/webdriver/browsers/config/BrowserThreads.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import static org.openqa.selenium.Proxy.ProxyType.MANUAL;
 import static org.sayem.webdriver.browsers.config.BrowserType.FIREFOX;
 import static org.sayem.webdriver.browsers.config.BrowserType.valueOf;
-
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**

--- a/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
+++ b/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
@@ -13,7 +13,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import static org.sayem.webdriver.TestBase.driver;
-
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**

--- a/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
+++ b/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
@@ -48,7 +48,6 @@ public class ScreenshotListener extends TestListenerAdapter {
             screenshotStream.close();
         } catch (IOException unableToWriteScreenshot) {
             log.error("Unable to write " + screenshot.getAbsolutePath(), unableToWriteScreenshot);
-            unableToWriteScreenshot.printStackTrace();
         }
     }
 
@@ -71,7 +70,6 @@ public class ScreenshotListener extends TestListenerAdapter {
             }
         } catch (Exception ex) {
             log.error("Unable to capture screenshot...", ex);
-            ex.printStackTrace();
         }
     }
 }

--- a/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
+++ b/src/main/java/org/sayem/webdriver/listeners/ScreenshotListener.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Augmenter;
+import org.slf4j.Logger;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 
@@ -13,10 +14,14 @@ import java.io.IOException;
 
 import static org.sayem.webdriver.TestBase.driver;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 /**
  * Created by sayem on 10/05/15.
  */
 public class ScreenshotListener extends TestListenerAdapter {
+
+    private static final Logger log = getLogger(ScreenshotListener.class);
 
     private boolean createFile(File screenshot) {
         boolean fileCreated = false;
@@ -43,7 +48,7 @@ public class ScreenshotListener extends TestListenerAdapter {
             screenshotStream.write(((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES));
             screenshotStream.close();
         } catch (IOException unableToWriteScreenshot) {
-            System.err.println("Unable to write " + screenshot.getAbsolutePath());
+            log.error("Unable to write " + screenshot.getAbsolutePath(), unableToWriteScreenshot);
             unableToWriteScreenshot.printStackTrace();
         }
     }
@@ -61,12 +66,12 @@ public class ScreenshotListener extends TestListenerAdapter {
                 } catch (ClassCastException weNeedToAugmentOurDriverObject) {
                     writeScreenshotToFile(new Augmenter().augment(driver), screenshot);
                 }
-                System.out.println("Written screenshot to " + screenshotAbsolutePath);
+                log.info("Written screenshot to " + screenshotAbsolutePath);
             } else {
-                System.err.println("Unable to create " + screenshotAbsolutePath);
+                log.error("Unable to create " + screenshotAbsolutePath);
             }
         } catch (Exception ex) {
-            System.err.println("Unable to capture screenshot...");
+            log.error("Unable to capture screenshot...", ex);
             ex.printStackTrace();
         }
     }

--- a/src/main/java/org/sayem/webdriver/listeners/TestNGRetry.java
+++ b/src/main/java/org/sayem/webdriver/listeners/TestNGRetry.java
@@ -3,10 +3,15 @@ package org.sayem.webdriver.listeners;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.slf4j.Logger;
+
 /**
  * Created by sayem on 2/2/16.
  */
 public class TestNGRetry implements IRetryAnalyzer {
+    private static final Logger log = getLogger(TestNGRetry.class);
     private int retryCount = 0;
     private int maxRetryCount = 1;
 
@@ -14,7 +19,7 @@ public class TestNGRetry implements IRetryAnalyzer {
     // and it takes the 'Result' as parameter of the test method that just ran
     public boolean retry(ITestResult result) {
         if (retryCount < maxRetryCount) {
-            System.out.println("Retrying test " + result.getName() + " with status "
+            log.info("Retrying test " + result.getName() + " with status "
                     + getResultStatusName(result.getStatus()) + " for the " + (retryCount+1) + " time(s).");
             retryCount++;
             return true;

--- a/src/main/java/org/sayem/webdriver/listeners/TestNGRetry.java
+++ b/src/main/java/org/sayem/webdriver/listeners/TestNGRetry.java
@@ -2,10 +2,9 @@ package org.sayem.webdriver.listeners;
 
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
+import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
-
-import org.slf4j.Logger;
 
 /**
  * Created by sayem on 2/2/16.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S106 Standard outputs should not be used directly to log anything.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS106
Please let me know if you have any questions.
George Kankava