### PR TITLE
squid:S1192 String literals should not be duplicated

### DIFF
--- a/src/main/java/org/sayem/webdriver/javascript/JavascriptActions.java
+++ b/src/main/java/org/sayem/webdriver/javascript/JavascriptActions.java
@@ -19,7 +19,9 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class JavascriptActions extends DelegatingWebDriver
         implements ExplicitWait, SearchScope, JavascriptExecutor {
 
-    public static final String NO_JQUERY_ERROR = "ReferenceError: $ is not defined";
+    private static final String J_QUERY_IS_NOT_DEFINED = "JQuery is not defined";
+	private static final String JS_ERROR = "JSError";
+	public static final String NO_JQUERY_ERROR = "ReferenceError: $ is not defined";
     Logger logger = getLogger(JavascriptActions.class);
     private WebDriver webDriver;
 
@@ -97,7 +99,7 @@ public class JavascriptActions extends DelegatingWebDriver
                     webDriver.findElement(elementBy));
         } catch (WebDriverException e) {
             if (e.getMessage().contains(NO_JQUERY_ERROR)) {
-                logger.info("JSError", "JQuery is not defined", false);
+                logger.info(JS_ERROR, J_QUERY_IS_NOT_DEFINED, false);
             }
         }
     }
@@ -111,7 +113,7 @@ public class JavascriptActions extends DelegatingWebDriver
             );
         } catch (WebDriverException e) {
             if (e.getMessage().contains(NO_JQUERY_ERROR)) {
-                logger.info("JSError", "JQuery is not defined", false);
+                logger.info(JS_ERROR, J_QUERY_IS_NOT_DEFINED, false);
             }
         }
     }
@@ -126,7 +128,7 @@ public class JavascriptActions extends DelegatingWebDriver
             );
         } catch (WebDriverException e) {
             if (e.getMessage().contains(NO_JQUERY_ERROR)) {
-                logger.info("JSError", "JQuery is not defined", false);
+                logger.info(JS_ERROR, J_QUERY_IS_NOT_DEFINED, false);
             }
         }
     }

--- a/src/main/java/org/sayem/webdriver/selenium/Browser.java
+++ b/src/main/java/org/sayem/webdriver/selenium/Browser.java
@@ -21,7 +21,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class Browser extends DelegatingWebDriver
         implements ExplicitWait, SearchScope {
 
-    public static final Logger log = getLogger(Browser.class);
+    private static final String VALUE2 = "value";
+	public static final Logger log = getLogger(Browser.class);
     private Action action;
     private JavascriptActions javascript;
     private MultiSelect select;
@@ -68,13 +69,13 @@ public class Browser extends DelegatingWebDriver
                     Element element = findElement(by);
                     element.clear();
                     element.sendKeys(value);
-                    assert value.equals(element.getAttribute("value"));
+                    assert value.equals(element.getAttribute(VALUE2));
                 }
         );
     }
 
     public String getInputText(Supplier<By> by) {
-        return untilFound(by).getAttribute("value");
+        return untilFound(by).getAttribute(VALUE2);
     }
 
     public void setCheckboxValue(Supplier<By> by, boolean value) {
@@ -94,7 +95,7 @@ public class Browser extends DelegatingWebDriver
         assert radiobuttons.size() >= 2;
 
         for (WebElement e : radiobuttons) {
-            if (e.getAttribute("value").equals(value)) {
+            if (e.getAttribute(VALUE2).equals(value)) {
                 e.click();
                 return;
             }
@@ -110,7 +111,7 @@ public class Browser extends DelegatingWebDriver
 
         for (WebElement e : radiobuttons) {
             if (Boolean.valueOf(e.getAttribute("checked"))) {
-                return e.getAttribute("value");
+                return e.getAttribute(VALUE2);
             }
         }
         return null;

--- a/src/main/java/org/sayem/webdriver/selenium/DatePicker.java
+++ b/src/main/java/org/sayem/webdriver/selenium/DatePicker.java
@@ -9,24 +9,26 @@ import java.time.format.DateTimeFormatter;
  */
 public class DatePicker {
 
-    public String todayDate() {
+    private static final String M_D_YYYY = "M/d/yyyy";
+
+	public String todayDate() {
         LocalDate date = LocalDate.now();
-        return date.format(DateTimeFormatter.ofPattern("M/d/yyyy"));
+        return date.format(DateTimeFormatter.ofPattern(M_D_YYYY));
     }
 
     public String addNumberOfDayToDate(int days) {
         LocalDate date = LocalDate.now().plusDays(days);
-        return date.format(DateTimeFormatter.ofPattern("M/d/yyyy"));
+        return date.format(DateTimeFormatter.ofPattern(M_D_YYYY));
     }
 
     public String addOneWeekToDate() {
         LocalDate date = LocalDate.now().plusWeeks(1);
-        return date.format(DateTimeFormatter.ofPattern("M/d/yyyy"));
+        return date.format(DateTimeFormatter.ofPattern(M_D_YYYY));
     }
 
     public String addOneMonthToDate() {
         LocalDate date = LocalDate.now().plusMonths(1);
-        return date.format(DateTimeFormatter.ofPattern("M/d/yyyy"));
+        return date.format(DateTimeFormatter.ofPattern(M_D_YYYY));
     }
 
     public String addNumberOfWeekDay(int workdays) {
@@ -39,7 +41,7 @@ public class DatePicker {
                 ++addedDays;
             }
         }
-        return result.format(DateTimeFormatter.ofPattern("M/d/yyyy"));
+        return result.format(DateTimeFormatter.ofPattern(M_D_YYYY));
     }
 
     public String addNumberOfWeekDayInReverse(int workdays) {

--- a/src/main/java/org/sayem/webdriver/selenium/MultiSelect.java
+++ b/src/main/java/org/sayem/webdriver/selenium/MultiSelect.java
@@ -19,7 +19,9 @@ import java.util.stream.Collectors;
 public class MultiSelect extends DelegatingWebDriver
         implements ExplicitWait, SearchScope {
 
-    public MultiSelect(WebDriver delegate) {
+    private static final String VALUE = "value";
+
+	public MultiSelect(WebDriver delegate) {
         super(delegate);
     }
 
@@ -141,7 +143,7 @@ public class MultiSelect extends DelegatingWebDriver
 
     public String getFirstSelectedValue(Supplier<By> by) {
         try {
-            return new Select(findElement(by)).getFirstSelectedOption().getAttribute("value");
+            return new Select(findElement(by)).getFirstSelectedOption().getAttribute(VALUE);
         } catch (NoSuchElementException e) {
             return null;
         }
@@ -150,7 +152,7 @@ public class MultiSelect extends DelegatingWebDriver
     public List<String> getAllSelectedValues(Supplier<By> by) {
         return new Select(findElement(by)).getAllSelectedOptions()
                 .stream()
-                .map(option -> option.getAttribute("value"))
+                .map(option -> option.getAttribute(VALUE))
                 .collect(Collectors.toList());
     }
 
@@ -183,7 +185,7 @@ public class MultiSelect extends DelegatingWebDriver
     public List<String> getAllValues(Supplier<By> by) {
         return new Select(findElement(by)).getOptions()
                 .stream()
-                .map(option -> option.getAttribute("value"))
+                .map(option -> option.getAttribute(VALUE))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava